### PR TITLE
AssetManger Named Regex Groups Bugfix

### DIFF
--- a/js/utilities/assetManager.js
+++ b/js/utilities/assetManager.js
@@ -85,7 +85,7 @@ AssetManager.prototype.loadAssets = function(callback) {
   else {
     for(var i=0; i < this.paths.length; i++) {
       const path = this.paths[i];
-      var fileExtension = path.match(/.+(?<extension>\.\w+)/).groups.extension;
+      var fileExtension = path.match(/.+(\.\w+)/)[1];
 
       switch (fileExtension) {
         case ".jpg":


### PR DESCRIPTION
### OVERVIEW
#### Back-End
 o changed regex grouping scheme in loadAssets() to simply access the .match array index 1 instead of using .groups.extension

### Note to the Author
>  This scheme change was done due to support being currently limited, rendering the entire game unplayable on many browser version.
>
>   REF: https //developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Browser_compatibility
> 
>     * Chrome            | Full support  v.64
>     * Edge              | Full support  v.79
>     * Firefox           | No support
>     * IE                | No support
>     * Opera             | Full support  v.51
>     * Safari            | Full support  v.11.1
>       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     * Webview (Android) | Full support  v.64
>     * Chrome (Android)  | Full support  v.64
>     * Firefox (Android) | No support
>     * Opera (Andriod)   | Full support  v.47
>     * Safari (iOS)      | Full support  v.11.3
>     * Samsung           | Full support  v.9.0
>     * NodeJS            | Full support  v.10.0.0

#### EDITS
 Regex grouping scheme change
  - [js/utilities/assetManager.js] changed from named groups to normal grouping, and accessing of match[1]
